### PR TITLE
Format strings like @"mm:ss' min'" may be invalid for TimeSpan

### DIFF
--- a/.github/workflows/dotnet-desktop.yml
+++ b/.github/workflows/dotnet-desktop.yml
@@ -52,11 +52,11 @@ jobs:
         platform: [x64, x86]
 
     runs-on: windows-latest  # For a list of available runner types, refer to
-                             # https://help.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idruns-on
+                            # https://help.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idruns-on
 
     env:
       Solution_Name: WindowsLayoutSnapshot.sln                  # Replace with your solution name, i.e. MyWpfApp.sln.
-      Project_Name: WindowsLayoutSnapshot.csproj
+      Project_Name: WindowsLayoutSnapshot/WindowsLayoutSnapshot.csproj
       #Test_Project_Path: your-test-project-path                 # Replace with the path to your test project, i.e. MyWpfApp.Tests\MyWpfApp.Tests.csproj.
       #Wap_Project_Directory: your-wap-project-directory-name    # Replace with the Wap project directory relative to the solution, i.e. MyWpfApp.Package.
       #Wap_Project_Path: your-wap-project-path                   # Replace with the path to your Wap project, i.e. MyWpf.App.Package\MyWpfApp.Package.wapproj.
@@ -65,32 +65,17 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v4
       with:
-        fetch-depth: 0
+      fetch-depth: 0
 
     # Install the .NET Core workload
     - name: Install .NET Core
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: 8.0.x
+      dotnet-version: 8.0.x
 
     # Add  MSBuild to the PATH: https://github.com/microsoft/setup-msbuild
     - name: Setup MSBuild.exe
       uses: microsoft/setup-msbuild@v2
-
-    # Restore the application to populate the obj folder with RuntimeIdentifiers
-    # - name: Restore the application
-    #   run: msbuild $env:Solution_Name /t:Restore /p:Configuration=$env:Configuration
-    #   env:
-    #     Configuration: ${{ matrix.configuration }}
-        
-    # - name: Build Solution
-    #   run: msbuild $env:Solution_Name /p:Configuration=Release /p:Platform="x86" /p:OutDir=${{ github.workspace }}/build-output
-
-    # - name: Upload build artifacts
-    #   uses: actions/upload-artifact@v4
-    #   with:
-    #     name: build-artifacts
-    #     path: ${{ github.workspace }}/build-output
 
     - name: Restore
       run: dotnet restore $env:Solution_Name

--- a/.github/workflows/dotnet-desktop.yml
+++ b/.github/workflows/dotnet-desktop.yml
@@ -38,11 +38,10 @@
 
 name: .NET Core Desktop
 
-on:
-  push:
-    branches: [ "master" ]
-  pull_request:
-    branches: [ "master" ]
+on: 
+  - push
+  - pull_request
+  - workflow_dispatch
 
 jobs:
 

--- a/.github/workflows/dotnet-desktop.yml
+++ b/.github/workflows/dotnet-desktop.yml
@@ -49,13 +49,14 @@ jobs:
 
     strategy:
       matrix:
-        configuration: [Debug]
+        platform: [x64, x86]
 
     runs-on: windows-latest  # For a list of available runner types, refer to
                              # https://help.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idruns-on
 
     env:
       Solution_Name: WindowsLayoutSnapshot.sln                  # Replace with your solution name, i.e. MyWpfApp.sln.
+      Project_Name: WindowsLayoutSnapshot.csproj
       #Test_Project_Path: your-test-project-path                 # Replace with the path to your test project, i.e. MyWpfApp.Tests\MyWpfApp.Tests.csproj.
       #Wap_Project_Directory: your-wap-project-directory-name    # Replace with the Wap project directory relative to the solution, i.e. MyWpfApp.Package.
       #Wap_Project_Path: your-wap-project-path                   # Replace with the path to your Wap project, i.e. MyWpf.App.Package\MyWpfApp.Package.wapproj.
@@ -77,16 +78,28 @@ jobs:
       uses: microsoft/setup-msbuild@v2
 
     # Restore the application to populate the obj folder with RuntimeIdentifiers
-    - name: Restore the application
-      run: msbuild $env:Solution_Name /t:Restore /p:Configuration=$env:Configuration
-      env:
-        Configuration: ${{ matrix.configuration }}
+    # - name: Restore the application
+    #   run: msbuild $env:Solution_Name /t:Restore /p:Configuration=$env:Configuration
+    #   env:
+    #     Configuration: ${{ matrix.configuration }}
         
-    - name: Build Solution
-      run: msbuild $env:Solution_Name /p:Configuration=Release /p:Platform="x86" /p:OutDir=${{ github.workspace }}/build-output
+    # - name: Build Solution
+    #   run: msbuild $env:Solution_Name /p:Configuration=Release /p:Platform="x86" /p:OutDir=${{ github.workspace }}/build-output
 
-    - name: Upload build artifacts
+    # - name: Upload build artifacts
+    #   uses: actions/upload-artifact@v4
+    #   with:
+    #     name: build-artifacts
+    #     path: ${{ github.workspace }}/build-output
+
+    - name: Restore
+      run: dotnet restore $env:Solution_Name
+
+    - name: Publish
+      run: dotnet publish $env:Project_Name -c Release -r win-${{ matrix.platform }} --self-contained true -p:PublishSingleFile=true -p:IncludeNativeLibrariesForSelfExtract=true -o ${{ github.workspace }}/publish/${{ matrix.platform }}
+
+    - name: Upload artifacts
       uses: actions/upload-artifact@v4
       with:
-        name: build-artifacts
-        path: ${{ github.workspace }}/build-output
+        name: build-${{ matrix.platform }}
+        path: ${{ github.workspace }}/publish/${{ matrix.platform }}

--- a/.github/workflows/dotnet-desktop.yml
+++ b/.github/workflows/dotnet-desktop.yml
@@ -77,6 +77,9 @@ jobs:
     - name: Setup MSBuild.exe
       uses: microsoft/setup-msbuild@v2
 
+    - name: Clean solution
+      run: dotnet clean $env:Solution_Name
+
     - name: Restore
       run: dotnet restore $env:Solution_Name
 

--- a/.github/workflows/dotnet-desktop.yml
+++ b/.github/workflows/dotnet-desktop.yml
@@ -65,13 +65,13 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v4
       with:
-      fetch-depth: 0
+        fetch-depth: 0
 
     # Install the .NET Core workload
     - name: Install .NET Core
       uses: actions/setup-dotnet@v4
       with:
-      dotnet-version: 8.0.x
+        dotnet-version: 8.0.x
 
     # Add  MSBuild to the PATH: https://github.com/microsoft/setup-msbuild
     - name: Setup MSBuild.exe

--- a/WindowsLayoutSnapshot/Common/UXFormat.cs
+++ b/WindowsLayoutSnapshot/Common/UXFormat.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Globalization;
 
 namespace WindowsLayoutSnapshot
@@ -17,12 +17,6 @@ namespace WindowsLayoutSnapshot
 
             if (t < 99)
             {
-                // note that TimeSpan can't represent less than 0.001ms
-                // 10.1ms
-                // 1.12ms
-                // 0.123ms
-                // 0.012ms
-                // 0.001ms
                 int digitsAfterPoint = 1;
                 double shifted = t;
                 for (int i = 0; i < 2 && shifted < 10; i++)
@@ -42,16 +36,29 @@ namespace WindowsLayoutSnapshot
                     : t.ToString("F", NumberFormatInfo.InvariantInfo) + "ms";
             }
 
-            if (sec < 60) return ts.ToString(@"s' sec'", NumberFormatInfo.InvariantInfo);
-            if (sec < 60 * 60) return ts.ToString(@"mm\:ss' min'", NumberFormatInfo.InvariantInfo);
-            if (sec < 24 * 60 * 60) return ts.ToString(@"hh\:mm' h'", NumberFormatInfo.InvariantInfo);
+            if (sec < 60)
+            {
+                ts = TimeSpan.FromSeconds(Math.Floor(ts.TotalSeconds));
+                return ts.ToString(@"s'sec'", CultureInfo.InvariantCulture);
+            }
+            if (sec < 60 * 60)
+            {
+                ts = TimeSpan.FromSeconds(Math.Floor(ts.TotalSeconds));
+                return ts.ToString(@"mm\:ss'min'", CultureInfo.InvariantCulture);
+            }
+            if (sec < 24 * 60 * 60)
+            {
+                ts = TimeSpan.FromMinutes(Math.Floor(ts.TotalMinutes));
+                return ts.ToString(@"hh\:mm'h'", CultureInfo.InvariantCulture);
+            }
 
-            return ts.ToString(@"d' days 'hh\:mm' h'", CultureInfo.InvariantCulture);
+            ts = TimeSpan.FromMinutes(Math.Floor(ts.TotalMinutes));
+            return ts.ToString(@"d'days 'hh\:mm'h'", CultureInfo.InvariantCulture);
         }
 
         public static bool IsCloseToWholeNumber(double d)
         {
-            const double EPS_ZERO = 0.0001; // 0.01->1% 0.0001 ->0.01%
+            const double EPS_ZERO = 0.0001;
             d = Math.Abs(d);
             return Math.Abs(Math.Round(d) - d) < EPS_ZERO;
         }

--- a/WindowsLayoutSnapshot/WindowsLayoutSnapshot.csproj
+++ b/WindowsLayoutSnapshot/WindowsLayoutSnapshot.csproj
@@ -1,13 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net8.0-windows</TargetFramework>
-    <Platform Condition=" '$(Platform)' == '' ">x86</Platform>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <OutputType>WinExe</OutputType>
     <UseWindowsForms>true</UseWindowsForms>
     <ImportWindowsDesktopTargets>true</ImportWindowsDesktopTargets>
     <ApplicationIcon>monitor-window-3d-shadow.ico</ApplicationIcon>
     <Nullable>enable</Nullable>
-    <Platforms>x86</Platforms>
+    <Platforms>AnyCPU</Platforms>
     <DebugType>embedded</DebugType>
   </PropertyGroup>
   


### PR DESCRIPTION
causing a System.FormatException error

## In a nutshell, this PR:

- does a `floor()` on `TimeSpan` to seconds for durations under an hour.
- For durations under an hour, it ensures `TimeSpan` formatting handles fractional seconds without error.

## Reasoning

All format strings miss seconds or fractions, like `@"hh:mm' h'"` lacking `'s'` or `'f'`.

To fix this, we will consider including all lower components or ensuring omitted parts are zero.

Since `ts` is arbitrary
- for: `sec<60`, `@"s' sec'"` fails if `ms!=0` 
- for: `<1hour`, `@"mm:ss' min'"` misses `'f'` if `ms!=0`

To fix:
- modify formats to include lower specifiers like `'s'` and `'f'` to handle all components.
- For each case, `floor` `TimeSpan` to the lowest unit displayed to ensure omitted components are zero.